### PR TITLE
Use patched version of hie-bios

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/fendor/hie-bios.git
+    tag: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -439,9 +439,9 @@ memoIO op = do
             Just res -> return (mp, res)
 
 setOptions :: GhcMonad m => ComponentOptions -> DynFlags -> m (DynFlags, [Target])
-setOptions (ComponentOptions theOpts _) dflags = do
+setOptions (ComponentOptions theOpts compRoot _) dflags = do
     cacheDir <- liftIO $ getCacheDir theOpts
-    (dflags', targets) <- addCmdOpts theOpts dflags
+    (dflags', targets) <- addCmdOpts compRoot theOpts dflags
     let dflags'' =
           -- disabled, generated directly by ghcide instead
           flip gopt_unset Opt_WriteInterface $

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,9 @@ extra-deps:
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
 - lsp-test-0.10.2.0
-- hie-bios-0.4.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - fuzzy-0.1.0.0
 - regex-pcre-builtin-0.95.1.1.8.43
 - regex-base-0.94.0.0

--- a/stack84.yaml
+++ b/stack84.yaml
@@ -11,7 +11,9 @@ extra-deps:
 - rope-utf16-splay-0.3.1.0
 - filepattern-0.1.1
 - js-dgtable-0.5.2
-- hie-bios-0.4.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - fuzzy-0.1.0.0
 - shake-0.18.5
 - time-compat-1.9.2.2

--- a/stack88.yaml
+++ b/stack88.yaml
@@ -4,6 +4,9 @@ packages:
 extra-deps:
 - haskell-lsp-0.21.0.0
 - haskell-lsp-types-0.21.0.0
+# - hie-bios-0.4.0
+- github: fendor/hie-bios
+  commit: d5b7fc9bb3025b1d4d2ac9c48b588faf18dfce99
 - lsp-test-0.10.2.0
 - ghc-check-0.1.0.3
 


### PR DESCRIPTION
To make hls buildable with stack (see https://github.com/haskell/haskell-language-server/pull/64)
//cc @alanz